### PR TITLE
add component packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+components
+build

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "store2",
+  "version": "2.1.1",
+  "main": "src/store2.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,10 +1,21 @@
 {
-  "name": "store2",
+  "name": "store",
+  "repo": "nbubna/store",
+  "description": "A better way to use localStorage and sessionStorage",
   "version": "2.1.1",
-  "main": "src/store2.js",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "components"
+  "keywords": ["localStorage","sessionStorage","json","namespace","store"],
+  "dependencies": {},
+  "development": {},
+  "license": "MIT",
+  "main": "src/component.js",
+  "scripts": [
+    "src/component.js",
+    "src/store2.js",
+    "src/store.bind.js",
+    "src/store.cache.js",
+    "src/store.measure.js",
+    "src/store.old.js",
+    "src/store.overflow.js",
+    "src/store.quota.js"
   ]
 }

--- a/src/component.js
+++ b/src/component.js
@@ -1,0 +1,3 @@
+
+module.exports = require('./store2.js');
+

--- a/test/store_component.html
+++ b/test/store_component.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>store.js Test Suite: using component build</title>
+  <!-- Load local jQuery. This can be overridden with a ?jquery=___ param. -->
+  <script src="../libs/jquery-loader.js"></script>
+  <!-- Load local QUnit. -->
+  <link rel="stylesheet" href="../libs/qunit/qunit.css" media="screen">
+  <script src="../libs/qunit/qunit.js"></script>
+  <!-- Load local lib and tests. Assumes you have run `component build` -->
+  <script src="../build/build.js"></script>
+  <script>
+    require('store');
+    require('store/src/store.bind.js');
+    require('store/src/store.cache.js');
+    require('store/src/store.old.js');
+    require('store/src/store.overflow.js');
+    require('store/src/store.quota.js');
+    require('store/src/store.measure.js');
+  </script>
+  <script src="store_test.js"></script>
+  <!-- Removing access to jQuery and $. But it'll still be available as _$, if
+       you REALLY want to mess around with jQuery in the console. REMEMBER WE
+       ARE TESTING A PLUGIN HERE, THIS HELPS ENSURE BEST PRACTICES. REALLY. -->
+  <script>window._$ = jQuery.noConflict(true);</script>
+</head>
+<body>
+  <h1 id="qunit-header">store.js - tests</h1>
+  <h2 id="qunit-banner"></h2>
+  <h2 id="qunit-userAgent"></h2>
+  <ol id="qunit-tests"></ol>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+</body>
+</html>


### PR DESCRIPTION
- move existing component.json => bower.json
- add test page for using component build

Looking at it now, I'm not sure component-izing it adds much value, except in terms of distribution, since it's designed as a singleton attached to `window` - and rightly so since it's basically a nice interface for a piece of infrastructure (localStorage/sessionStorage). You don't need more than one `store()`. But anyway this lets people `component install` it. Personally I might just use it directly through script tags.
