### PR TITLE
Update store.overflow.js

### DIFF
--- a/src/store.overflow.js
+++ b/src/store.overflow.js
@@ -42,7 +42,10 @@
             _set.apply(this, arguments);
         } catch (e) {
             if (e.name === 'QUOTA_EXCEEDED_ERR' ||
-                e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+                e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+                e.toString().indexOf("QUOTA_EXCEEDED_ERR") != -1 ||
+                e.toString().indexOf("QuotaExceededError") != -1) {
+                // the e.toString is needed for IE9 / IE10, cos name is empty there
                 return _.set(_.overflow(area, true), key, string);
             }
             throw e;


### PR DESCRIPTION
So in my IE9 the overflow functions werent working.
I checked why. And came to the conclusion that e.name is undefined in IE9.
But i found out that e.toString() gives nevertheless the string to compare it.
And i just read that ie10 will return "QuotaExceededError".

See: http://msdn.microsoft.com/en-us/library/ie/gg592979(v=vs.85).aspx 
