### PR TITLE
Changed cache to use seconds instead of minutes.

### DIFF
--- a/src/store.cache.js
+++ b/src/store.cache.js
@@ -28,8 +28,8 @@
         return false;
     };
     _.when = function(min) {// if min, return min->date, else date->min
-        var now = Math.floor((new Date().getTime())/60000);
-        return min ? new Date((now+min)*60000) : now;
+        var now = Math.floor((new Date().getTime())/1000);
+        return min ? new Date((now+min)*1000) : now;
     };
     _.cache = function(area, key) {
         var s = _get(area, key),


### PR DESCRIPTION
I have changed the cache plugin to use seconds instead of minutes for the expiration.

The problem with using minutes is that an uninformed user, it can appear that the cache simple does not work right and expires too soon. The plugin uses the client's local clock in order to determine if the cache is expired or not. The problem is that, the plugin simply checks if the clock has reached the expiration minute or not and doesn't consider the seconds until the next minute when setting the expiration. Example:

Your systems clock is 1:00:55. You set a value to expire in 1 minute: `store.set('hello','world',1);` You expect the value to be expired in 1 minute (60 seconds) from the time you set the value. But the value actually expires in 5 seconds, when the system clock hits 1:01:00. This can be very misleading and confusing if you are using `store.js` in a client side app with lots of short term (sub-minute) local storage caching.

So this PR changes the plugin to require the user to specify seconds of expiration instead of minutes. So if the user wanted to expire something in 1 minute, he would simply do `store.set('hello','world',60);`. It's more straightforward and I think more what the user would be expecting regarding setting a cache and obviously it allows for sub-minute expiration times.