### PR TITLE
#15 Explicit name set fixes the issue with Require not being able to match the module.

### DIFF
--- a/src/store2.js
+++ b/src/store2.js
@@ -224,7 +224,7 @@
     window.store = store;
 
     if (typeof define === 'function' && define.amd !== undefined) {
-        define(function () {
+        define(['store'], function () {
             return store;
         });
     } else if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
Explicit name set fixes the issue with Require not being able to match the module.
`require.js:900 Error: Mismatched anonymous define() module: undefined`

Implementing this, solves the issue for me.
