### PR TITLE
Include types in files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "main": "dist/store2.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Doesn't look like the TypeScript declaration file is included when fetching the package from npm. I'm assuming the reason for that is the `files` array in `package.json`. This would hopefully fix that.