### PR TITLE
removed eval use from deep.store.js

### DIFF
--- a/src/store.deep.js
+++ b/src/store.deep.js
@@ -9,14 +9,14 @@
  *   store.set('foo', { is: { not: { quite: false }}});
  *   console.log(store.get('foo.is.not.quite'));// logs false
  *
- * Status: ALPHA - currently only supports get, inefficient, uses eval
+ * Status: ALPHA - currently only supports get
  */
-;(function(_) {
+; (function (_) {
 
     // save original core accessor
     var _get = _.get;
     // replace with enhanced version
-    _.get = function(area, key, kid) {
+    _.get = function (area, key, kid) {
         var s = _get(area, key);
         if (s == null) {
             var parts = _.split(key);
@@ -26,19 +26,28 @@
                 return _.get(area, parts[0], kid);
             }
         } else if (kid) {
-            var val = _.parse(s);
-            /*jshint evil:true */
-            val = eval("val."+kid);
-            s = _.stringify(val);
+            try {
+                var val = _.parse(s);
+                val = _.resolvePath(val, kid);
+                s = _.stringify(val);
+            } catch (e) {
+                console.error("Error accessing nested property:", e);
+                return null;
+            }
         }
         return s;
     };
 
+    // Helper function to resolve nested paths safely
+    _.resolvePath = function (obj, path) {
+        return path.split('.').reduce((acc, key) => acc && acc[key], obj);
+    };
+
     // expose internals on the underscore to allow extensibility
-    _.split = function(key) {
+    _.split = function (key) {
         var dot = key.lastIndexOf('.');
         if (dot > 0) {
-            var kid = key.substring(dot+1, key.length);
+            var kid = key.substring(dot + 1, key.length);
             key = key.substring(0, dot);
             return [key, kid];
         }


### PR DESCRIPTION
Removed eval from `deep.store.js` to rpevent any XSS vulnerabilities that could arise by bad implementations.